### PR TITLE
Handle jobs without IDs (i.e., which have errors)

### DIFF
--- a/crowdflower/connection.py
+++ b/crowdflower/connection.py
@@ -97,7 +97,10 @@ class Connection(object):
             jobs_response = self.request('/jobs', params=params)
             for job_properties in jobs_response:
                 # somehow add the Job's properties to the cache, since we have all the data anyway?
-                yield job_properties['id']
+                if 'id' in job_properties:
+                    yield job_properties['id']
+                else:
+                    continue
             if len(jobs_response) < 10:
                 break
 


### PR DESCRIPTION
Some of my jobs have errors, which means the JSON returned from the CrowdFlower server is not complete. For those jobs, this is what `job_properties` looks like:

```
>>> repr(job_properties)
Out[2]: "{u'errors': [u'You need to have more units per task than test questions per task. If you need to show 1 unit per page, you can choose 2 units per task and 2 pages per task', None]}"
```

There is no `'id'` property; hence, `connection.job_ids()` fails with a `KeyError`:
```
  File "/usr/local/lib/python2.7/site-packages/crowdflower/connection.py", line 112, in jobs
    for job_id in self.job_ids:
  File "/usr/local/lib/python2.7/site-packages/crowdflower/cache.py", line 77, in wrapper
    value = flatten(value)
  File "/usr/local/lib/python2.7/site-packages/crowdflower/cache.py", line 34, in flatten
    return list(obj)
  File "/usr/local/lib/python2.7/site-packages/crowdflower/connection.py", line 101, in job_ids
    yield job_properties['id']
KeyError: 'id'
```

In this PR, I changed `job_ids()` to only yield a job ID if the job JSON has been properly parsed. Otherwise, as far as the user knows, the job doesn't exist.