### PR TITLE
Download other results; regenerate CSVs

### DIFF
--- a/crowdflower/job.py
+++ b/crowdflower/job.py
@@ -373,33 +373,32 @@ class Job(object):
     def judgments(self):
         return self.download()
 
-    def download_csv(self, filepath, full=None, type='results'):
+    def download_csv(self, filepath, full=None, type='full'):
         '''
         Basically the same as job.judgments but without parsing the csv.
 
-        If full is not given and type='results', full defaults to True
+        full is ignored unless it is False, in which case type is set to
+        'aggregated'.
+
         Other supported types are given at:
         https://success.crowdflower.com/hc/en-us/articles/202703425-CrowdFlower-API-Requests-Guide#get_results
         (Though, as of 2015-05-13, some, such as 'source' and 'workset' are
         not documented)
 
-        If a type other than 'results' is given, full is ignored.
+        If a type other than 'full' is given, full is ignored.
         '''
 
         # Advantage of catching the error here is we can give a more useful
         # error message
         # The disadvantage is that we have to explicitly encode parts of the
         # API that may be incomplete or may change
-        valid_types = {'results', 'full', 'aggregated', 'source', 'workset'}
+        valid_types = {'full', 'aggregated', 'source', 'workset'}
         if type not in valid_types:
             raise ResultsTypeError(type, valid_types)
 
-        if type == 'results':
-            if full is None:
-                full = True
-            params = dict(type='full' if full else 'aggregated')
-        else:
-            params = dict(type=type)
+        if full is not None:
+            type = 'full' if full else 'aggregated'
+        params = dict(type=type)
 
         req = self._connection.create_request('/jobs/%s.csv' % self.id, method='GET', params=params)
         res = self._connection.send_request(req)

--- a/crowdflower/job.py
+++ b/crowdflower/job.py
@@ -402,7 +402,9 @@ class Job(object):
             result_type = 'full' if full else 'aggregated'
         params = dict(type=result_type)
 
-        req = self._connection.create_request('/jobs/%s.csv' % self.id, method='GET', params=params)
+        req = self._connection.create_request('/jobs/%s.csv' % self.id,
+                                              method='GET',
+                                              params=params)
         res = self._connection.send_request(req)
         fp = StringIO()
         fp.write(res.content)
@@ -415,8 +417,8 @@ class Job(object):
     def regenerate_csv(self, result_type):
         '''Regenerate the CSV on the server
 
-        Blocks until regeneration is complete, which can take a while for
-        jobs with many units.
+        May return before regeneration is complete, in which case, you will need
+        to wait a bit before download the CSV will succeed.
 
         :param result_type: any valid result_type that can be passed to
         download_csv, e.g., 'full', 'aggregated', 'source', etc.
@@ -426,5 +428,7 @@ class Job(object):
             raise ResultsTypeError(result_type)
 
         params = dict(type=result_type)
-        req = self._connection.create_request('/jobs/%s/regenerate' % self.id, method='POST', params=params)
+        req = self._connection.create_request('/jobs/%s/regenerate' % self.id,
+                                              method='POST',
+                                              params=params)
         self._connection.send_request(req)

--- a/crowdflower/job.py
+++ b/crowdflower/job.py
@@ -368,12 +368,10 @@ class Job(object):
             for row in reader:
                 yield {key: value.decode('utf8') for key, value in row.items()}
 
-
     @property
     @cacheable()
     def judgments(self):
         return self.download()
-
 
     def download_csv(self, filepath, full=None, type='results'):
         '''
@@ -412,3 +410,13 @@ class Job(object):
         fsrc = zf.open(zipinfo)
         with open(filepath, 'w') as fdst:
             shutil.copyfileobj(fsrc, fdst)
+
+    def regenerate_csv(self, type):
+        '''Regenerate the CSV on the server
+        :param type: any valid type that can be passed to download_csv,
+        e.g., 'full', 'aggregated', 'source', etc.
+        '''
+
+        params = dict(type=type)
+        req = self._connection.create_request('/jobs/%s/regenerate' % self.id, method='POST', params=params)
+        self._connection.send_request(req)

--- a/crowdflower/job.py
+++ b/crowdflower/job.py
@@ -11,6 +11,21 @@ from crowdflower.cache import cacheable, keyfunc
 from crowdflower.serialization import rails_params
 
 
+# Thrown if user requests an invalid type when downloading a CSV
+class ResultsTypeError(Exception):
+    def __init__(self, results_type, valid_results_types):
+        self.results_type = results_type
+        self.valid_results_types = valid_results_types
+
+    def __repr__(self):
+        return 'Results type %s is not in %r' % (
+            self.results_type,
+            self.valid_results_types
+        )
+
+    __str__ = __repr__
+
+
 class Job(object):
     '''
     Read / Write attributes
@@ -360,11 +375,34 @@ class Job(object):
         return self.download()
 
 
-    def download_csv(self, filepath, full=True):
+    def download_csv(self, filepath, full=None, type='results'):
         '''
         Basically the same as job.judgments but without parsing the csv.
+
+        If full is not given and type='results', full defaults to True
+        Other supported types are given at:
+        https://success.crowdflower.com/hc/en-us/articles/202703425-CrowdFlower-API-Requests-Guide#get_results
+        (Though, as of 2015-05-13, some, such as 'source' and 'workset' are
+        not documented)
+
+        If a type other than 'results' is given, full is ignored.
         '''
-        params = dict(full='true' if full else 'false')
+
+        # Advantage of catching the error here is we can give a more useful
+        # error message
+        # The disadvantage is that we have to explicitly encode parts of the
+        # API that may be incomplete or may change
+        valid_types = {'results', 'full', 'aggregated', 'source', 'workset'}
+        if type not in valid_types:
+            raise ResultsTypeError(type, valid_types)
+
+        if type == 'results':
+            if full is None:
+                full = True
+            params = dict(type='full' if full else 'aggregated')
+        else:
+            params = dict(type=type)
+
         req = self._connection.create_request('/jobs/%s.csv' % self.id, method='GET', params=params)
         res = self._connection.send_request(req)
         fp = StringIO()


### PR DESCRIPTION
Adds support for:

* Downloading source and contributor ("workset") results in addition to full and aggregated results. These work but are missing from the documentation at https://success.crowdflower.com/hc/en-us/articles/202703425-CrowdFlower-API-Requests-Guide#get_results
* Regenerating results for all four of those types

Missing:
* Other result types (e.g., JSON, test questions)
* Updates to the `job.download()` function; I only updated `job.download_csv()`.